### PR TITLE
Unit test + fix for regex chaining

### DIFF
--- a/conjure/spec.py
+++ b/conjure/spec.py
@@ -2,6 +2,8 @@ import copy
 import types
 import collections
 import re
+try: import cPickle as pickle
+except ImportException: import pickle
 
 
 class Specification(object):
@@ -201,6 +203,9 @@ class QuerySpecification(Specification):
 
     def __invert__(self):
         return QuerySpecification(self._invert_op('not'))
+
+    def __deepcopy__(self, memo):
+        return pickle.loads(pickle.dumps(self))
 
 
 class Equal(QuerySpecification):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -431,6 +431,24 @@ class QueryTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+    def test_chain_regex(self):
+        class TextHolder(documents.Document):
+            data = fields.StringField()
+            
+        TextHolder.drop_collection()
+
+        text1 = TextHolder(data='Hello')
+        text2 = TextHolder(data='hello')
+        
+        text1.save()
+        text2.save()
+
+        obs = TextHolder.objects.filter(TextHolder.data.icontains('hello'))
+
+        obs = obs.filter(TextHolder.data.icontains('ello'))
+
+        self.assertEqual(len(obs), 2)
+
     def tearDown(self):
         self.User.drop_collection()
 


### PR DESCRIPTION
Less hack-ish than the old version.  Added new unit test that reproduces bug (and will fail) if the spec.py change is not present.

All tests pass with patch in full.