### PR TITLE
Convert DictField datetime values to unix timestamp

### DIFF
--- a/conjure/base.py
+++ b/conjure/base.py
@@ -268,7 +268,7 @@ class BaseField(Common):
         elif  'parent_field' in self.owner._meta:
             parent_field = self.owner._meta['parent_field']
 
-            if positional and parent_field.owner.__class__.__name__ == 'ListField':
+            if positional and parent_field.owner.__class__.__name__ == 'ListField' and self.__class__.__name__ != 'DictField':
                 sep = '.$.'
             else:
                 sep = '.'

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -224,14 +224,14 @@ class BaseDocument(object):
         return j
 
     def validate(self):
-        fields = [(field, getattr(self, name)) for name, field in self._fields.iteritems()]
+        fields = [(field, getattr(self, name), name) for name, field in self._fields.iteritems()]
 
-        for field, value in fields:
+        for field, value, name in fields:
             if value is not None:
                 try:
                     field._validate(value)
                 except (ValueError, AttributeError, AssertionError):
-                    raise ValidationError('Invalid value for field of type "' +
+                    raise ValidationError('Invalid value for field %s of type "'%name +
                                                      field.__class__.__name__ + '"')
             elif not (isinstance(field, ObjectIdField) and field.name == 'id') and field.required:
                 raise ValidationError('Field "%s" is required' % field.name)
@@ -318,7 +318,7 @@ class BaseField(Common):
     def _validate(self, value):
         if self.choices:
             if value not in map(itemgetter(0), self.choices):
-                raise ValidationError('Value must be one of %s.' % unicode(self.choices))
+                raise ValidationError('Field %s: Value must be one of %s.' % (self.name, unicode(self.choices)))
 
         for validator in self.validators:
             validator(value)

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -288,7 +288,7 @@ class BaseField(Common):
         value = instance._data.get(self.name)
 
         if value is None:
-            value = self.get_default()
+            value = copy.deepcopy(self.get_default())
             instance._data[self.name] = value
 
         return value

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -201,7 +201,7 @@ class BaseDocument(object):
 
         return doc
 
-    def to_json(self, only=None, methods=None):
+    def to_json(self, only=None, methods=None, external=False):
         j = {}
 
         only = only or self._fields.keys()
@@ -210,6 +210,9 @@ class BaseDocument(object):
             field = self._fields[field_name]
 
             if not field.serialize:
+                continue
+
+            if field.internal and external:
                 continue
 
             value = field.to_json(getattr(self, field_name))
@@ -248,7 +251,7 @@ class BaseDocument(object):
 
 class BaseField(Common):
     def __init__(self, verbose_name=None, db_field=None, required=False, default=None, validators=None, choices=None,
-                 editable=True, help_text='', serialize=True):
+                 editable=True, help_text='', serialize=True, internal=False):
 
         self.owner = None
         self.name = None
@@ -261,6 +264,7 @@ class BaseField(Common):
         self.editable = editable
         self.help_text = help_text
         self.serialize = serialize
+        self.internal = internal
 
     def get_key(self, positional=False):
         if isinstance(self.owner, BaseField):

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -318,7 +318,7 @@ class BaseField(Common):
     def _validate(self, value):
         if self.choices:
             if value not in map(itemgetter(0), self.choices):
-                raise ValidationError('Field %s: Value must be one of %s.' % (self.name, unicode(self.choices)))
+                raise ValidationError('Field %s: Value %s must be one of %s.' % (self.name, value, unicode(self.choices)))
 
         for validator in self.validators:
             validator(value)

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -317,7 +317,11 @@ class BaseField(Common):
 
     def _validate(self, value):
         if self.choices:
-            if value not in map(itemgetter(0), self.choices):
+            if len(self.choices) and isinstance(self.choices[0], tuple):
+                choices_list = map(itemgetter(0), self.choices)
+            else:
+                choices_list = self.choices
+            if value not in choices_list:
                 raise ValidationError('Field %s: Value %s must be one of %s.' % (self.name, value, unicode(self.choices)))
 
         for validator in self.validators:

--- a/conjure/base.py
+++ b/conjure/base.py
@@ -215,7 +215,7 @@ class BaseDocument(object):
             if field.internal and external:
                 continue
 
-            value = field.to_json(getattr(self, field_name))
+            value = field.to_json(getattr(self, field_name), external=external)
 
             if value is not None:
                 j[field_name] = value
@@ -313,7 +313,7 @@ class BaseField(Common):
     def to_mongo(self, value):
         return self.to_python(value)
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         return self.to_python(value)
 
     def validate(self, value):
@@ -366,7 +366,7 @@ class ObjectIdField(BaseField):
 
         return value
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         if isinstance(value, bson.objectid.ObjectId):
             return str(value)
 

--- a/conjure/fields.py
+++ b/conjure/fields.py
@@ -146,7 +146,7 @@ class DictField(BaseField):
 
     def to_json(self, value):
         if not value:
-            return None
+            return self.get_default()
         json_dict = {}
         for k,v in value.iteritems():
             if isinstance(v, datetime.datetime):

--- a/conjure/fields.py
+++ b/conjure/fields.py
@@ -144,6 +144,15 @@ class DictField(BaseField):
 
         return Proxy(key, self)
 
+    def to_json(self, value):
+        json_dict = {}
+        for k,v in value.iteritems():
+            if isinstance(v, datetime.datetime):
+                json_dict[k] = int(time.mktime(v.timetuple()))
+            else:
+                json_dict[k] = v
+        return json_dict
+
 
 class ListField(List, BaseField):
     def __init__(self, field, default=None, **kwargs):

--- a/conjure/fields.py
+++ b/conjure/fields.py
@@ -145,6 +145,8 @@ class DictField(BaseField):
         return Proxy(key, self)
 
     def to_json(self, value):
+        if not value:
+            return None
         json_dict = {}
         for k,v in value.iteritems():
             if isinstance(v, datetime.datetime):

--- a/conjure/fields.py
+++ b/conjure/fields.py
@@ -114,7 +114,7 @@ class DateTimeField(BaseField):
     def validate(self, value):
         assert isinstance(value, datetime.datetime)
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         if isinstance(value, datetime.datetime):
             return int(time.mktime(value.timetuple()))
 
@@ -144,7 +144,7 @@ class DictField(BaseField):
 
         return Proxy(key, self)
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         if not value:
             return self.get_default()
         json_dict = {}
@@ -200,8 +200,8 @@ class ListField(List, BaseField):
     def to_mongo(self, value):
         return [self.field.to_mongo(item) for item in value]
 
-    def to_json(self, value):
-        return [self.field.to_json(item) for item in value]
+    def to_json(self, value, external=False):
+        return [self.field.to_json(item, external=external) for item in value]
 
     def validate(self, value):
         if not isinstance(value, (list, tuple)):
@@ -251,9 +251,9 @@ class MapField(BaseField):
     def to_mongo(self, value):
         return dict((k, self.field.to_mongo(item)) for k, item in value.iteritems())
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         value = value or {}
-        return dict((k, self.field.to_json(item)) for k, item in value.iteritems())
+        return dict((k, self.field.to_json(item, external=external)) for k, item in value.iteritems())
 
     def validate(self, value):
         if not isinstance(value, dict):
@@ -336,9 +336,9 @@ class EmbeddedDocumentField(BaseField):
     def to_mongo(self, value):
         return self.document.to_mongo(value)
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         if isinstance(value, self.document):
-            return value.__class__.to_json(value)
+            return value.__class__.to_json(value, external=external)
 
     def validate(self, value):
         if not isinstance(value, self.document):
@@ -409,9 +409,9 @@ class ReferenceField(BaseField, Reference):
 
         return field.to_mongo(doc_id)
 
-    def to_json(self, value):
+    def to_json(self, value, external=False):
         if isinstance(value, Document):
-            return self.document_cls.to_json(value)
+            return self.document_cls.to_json(value, external=external)
 
     def validate(self, value):
         if isinstance(value, Document):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ DESCRIPTION = "A MongoDB object mapper inspired by Django models and SQLAlchemy'
 with open('README') as f:
     LONG_DESCRIPTION = f.read()
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 CLASSIFIERS = [
     'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     install_requires=[
-        'pymongo>=2.7.2',
+        'pymongo>=2.7.2,<3.0',
     ],
     platforms=['any'],
     classifiers=CLASSIFIERS,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -190,6 +190,28 @@ class FieldTest(unittest.TestCase):
 
         post.validate()
 
+    def test_list_of_dict_query(self):
+        class BlogComment(documents.EmbeddedDocument):
+            data = fields.DictField()
+
+        class BlogPost(documents.Document):
+            comments = fields.ListField(fields.EmbeddedDocumentField(BlogComment))
+            
+        post = BlogPost()
+        
+        post.comments = [BlogComment(data={
+            'author': 'Sam Smith'
+             })]
+        
+        post.validate()
+
+        post.save()
+
+        self.assertTrue(BlogPost.objects.filter(BlogComment.data['author'] == 'Sam Smith').one() != None)
+
+        BlogPost.drop_collection()
+
+
     def test_embedded_document_validation(self):
         class Comment(documents.EmbeddedDocument):
             content = fields.StringField()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -190,6 +190,47 @@ class FieldTest(unittest.TestCase):
 
         post.validate()
 
+    def test_defaulting(self):
+        class FlagContainer(documents.Document):
+            id = fields.StringField(db_field='_id')
+            flags = fields.DictField(default = {})
+            class Meta:
+                collection = 'flag_container'
+
+        class FlagContainer2(documents.Document):
+            id = fields.StringField(db_field='_id')
+            class Meta:
+                collection = 'flag_container'
+
+        FlagContainer.drop_collection()
+
+        FlagContainer2(id='a').save()
+        FlagContainer2(id='b').save()
+        FlagContainer2(id='c').save()
+        FlagContainer2(id='d').save()
+
+        fc = FlagContainer.objects.filter(FlagContainer.id=='a').one()
+        fc.flags['flag_a'] = True
+        fc.save()
+        self.assertEqual(len(fc.flags), 1)
+
+        fc = FlagContainer.objects.filter(FlagContainer.id=='b').one()
+        fc.flags['flag_b'] = True
+        fc.save()
+        self.assertEqual(len(fc.flags), 1)
+
+        fc = FlagContainer.objects.filter(FlagContainer.id=='c').one()
+        fc.flags['flag_c'] = True
+        fc.save()
+        self.assertEqual(len(fc.flags), 1)
+
+        fc = FlagContainer.objects.filter(FlagContainer.id=='d').one()
+        fc.flags['flag_d'] = True
+        fc.save()
+        self.assertEqual(len(fc.flags), 1)
+
+        FlagContainer.drop_collection()
+
     def test_list_of_dict_query(self):
         class BlogComment(documents.EmbeddedDocument):
             data = fields.DictField()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -410,6 +410,24 @@ class FieldTest(unittest.TestCase):
 
         self.assertEqual(shirt.get_size_display(), 'Small')
 
+    def test_choices_list(self):
+        class Shirt(documents.Document):
+            size = fields.StringField(choices=['Small', 'Medium', 'Large'])
+
+        Shirt.drop_collection()
+
+        shirt = Shirt()
+        shirt.validate()
+
+        shirt.size = 'Small'
+        shirt.validate()
+
+        shirt.size = 'Extra Small'
+        self.assertRaises(exceptions.ValidationError, shirt.validate)
+
+        Shirt.drop_collection()
+
+
     def test_map_field(self):
         class Group(documents.EmbeddedDocument):
             name = fields.StringField()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -183,6 +183,12 @@ class FieldTest(unittest.TestCase):
 
         self.assertTrue(isinstance(json_post['info']['timestamp'], int))
 
+        post.info = None
+
+        #make sure it can serialize with a null dictfield
+        self.assertFalse('info' in post.to_json())
+
+        post.validate()
 
     def test_embedded_document_validation(self):
         class Comment(documents.EmbeddedDocument):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -169,6 +169,21 @@ class FieldTest(unittest.TestCase):
         post.info = {'title': 'test'}
         post.validate()
 
+
+    def test_dict_datetime(self):
+        class BlogPost(documents.Document):
+            info = fields.DictField()
+
+        post = BlogPost()
+
+        post.info = {'timestamp': datetime.datetime.now()}
+        post.validate()
+
+        json_post = post.to_json()
+
+        self.assertTrue(isinstance(json_post['info']['timestamp'], int))
+
+
     def test_embedded_document_validation(self):
         class Comment(documents.EmbeddedDocument):
             content = fields.StringField()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -52,3 +52,25 @@ class JsonTest(unittest.TestCase):
 
         User.drop_collection()
         BlogPost.drop_collection()
+
+    def test_internal_json(self):
+        class User(conjure.Document):
+            name = conjure.StringField()
+            age = conjure.IntegerField()
+            salary = conjure.FloatField(internal=True)
+
+        user = User(name='Andrew',
+                    age=30,
+                    salary=50000.25)
+
+        user_json_internal = user.to_json()
+        user_json_external = user.to_json(external=True)
+        
+        self.assertEqual(user.name, user_json_internal['name'])
+        self.assertEqual(user.name, user_json_external['name'])
+
+        self.assertEqual(user.age, user_json_internal['age'])
+        self.assertEqual(user.age, user_json_external['age'])
+
+        self.assertEqual(user.salary, user_json_internal['salary'])
+        self.assertFalse('salary' in user_json_external)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -54,14 +54,28 @@ class JsonTest(unittest.TestCase):
         BlogPost.drop_collection()
 
     def test_internal_json(self):
+        class UserContacts(conjure.EmbeddedDocument):
+            emergency = conjure.StringField(internal=True)
+            manager = conjure.StringField()
+
+        class UserPreferences(conjure.EmbeddedDocument):
+            email_enabled = conjure.BooleanField()
+
         class User(conjure.Document):
             name = conjure.StringField()
             age = conjure.IntegerField()
             salary = conjure.FloatField(internal=True)
+            prefs = conjure.EmbeddedDocumentField(UserPreferences, internal=True)
+            contacts = conjure.EmbeddedDocumentField(UserContacts)
+            
 
         user = User(name='Andrew',
                     age=30,
-                    salary=50000.25)
+                    salary=50000.25,
+                    prefs = UserPreferences(email_enabled=True),
+                    contacts = UserContacts(emergency='e_contact',
+                                            manager='mgr_contact')
+        )
 
         user_json_internal = user.to_json()
         user_json_external = user.to_json(external=True)
@@ -74,3 +88,9 @@ class JsonTest(unittest.TestCase):
 
         self.assertEqual(user.salary, user_json_internal['salary'])
         self.assertFalse('salary' in user_json_external)
+
+        self.assertEqual(user.prefs.email_enabled, user_json_internal['prefs']['email_enabled'])
+        self.assertFalse('prefs' in user_json_external)
+
+        self.assertEqual(user.contacts.emergency, user_json_internal['contacts']['emergency'])
+        self.assertFalse('emergency' in user_json_external['contacts'])


### PR DESCRIPTION
Slight inconsistency when using to_json to serialize DateTimeField vs DictField that contained datetime values.  datetime values in DictField will now serialize to unix timestamps.

Unit test added for new behavior, 69/69 working for me.
